### PR TITLE
feat: add swagger with zod

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,16 +12,19 @@
   "author": "Alexandre, Florian, Tarik",
   "license": "ISC",
   "dependencies": {
+    "@asteasolutions/zod-to-openapi": "^7.3.2",
     "cors": "^2.8.5",
     "dotenv": "^16.5.0",
     "express": "^4.21.2",
     "mongoose": "^8.15.1",
+    "swagger-ui-express": "^5.0.1",
     "zod": "^3.25.51"
   },
   "devDependencies": {
     "@types/cors": "^2.8.17",
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.21",
+    "@types/swagger-ui-express": "^4.1.8",
     "nodemon": "^3.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import { SERVER } from './config/server';
 import { DEVELOPMENT } from './config/server';
 import { setupRoutes } from './routes/routes';
 import { setupMiddlewares } from './middleware/middlewares';
+import { setupSwagger } from './swagger/config';
 
 const app = express();
 
@@ -15,6 +16,10 @@ connectDB();
 
 // Setup routes
 setupRoutes(app);
+
+// Setup swagger documentation
+app.use('/api-docs', setupSwagger());
+console.log(`Documentation API disponible sur http://${SERVER.hostname}:${SERVER.port}/api-docs`);
 
 
 app.listen(SERVER.port, SERVER.hostname, () => {

--- a/src/schemas/userSchema.ts
+++ b/src/schemas/userSchema.ts
@@ -1,16 +1,34 @@
+import { extendZodWithOpenApi } from '@asteasolutions/zod-to-openapi';
 import { z } from 'zod';
 
+extendZodWithOpenApi(z);
+
 export const userSchema = z.object({
-  nom: z.string().min(2, "Le nom doit contenir au moins 2 caractères"),
-  prenom: z.string().min(2, "Le prénom doit contenir au moins 2 caractères"),
-  mail: z.string().email("Format d'email invalide"),
-  telephone: z.string().regex(/^(\+\d{1,3}[- ]?)?\d{10}$/, "Format de téléphone invalide"),
-  nationalite: z.string().min(2, "La nationalité doit contenir au moins 2 caractères")
-});
+  nom: z.string()
+    .min(2, "Le nom doit contenir au moins 2 caractères")
+    .openapi({ example: "Dupont", description: "Nom de l'utilisateur" }),
+
+  prenom: z.string()
+    .min(2, "Le prénom doit contenir au moins 2 caractères")
+    .openapi({ example: "Jean", description: "Prénom de l'utilisateur" }),
+
+  mail: z.string()
+    .email("Format d'email invalide")
+    .openapi({ example: "jean.dupont@example.com", description: "Adresse e-mail valide" }),
+
+  telephone: z.string()
+    .regex(/^(\+\d{1,3}[- ]?)?\d{10}$/, "Format de téléphone invalide")
+    .openapi({ example: "+33612345678", description: "Numéro de téléphone au format international ou FR" }),
+
+  nationalite: z.string()
+    .min(2, "La nationalité doit contenir au moins 2 caractères")
+    .openapi({ example: "Française", description: "Nationalité de l'utilisateur" }),
+}).openapi("UserInput");
 
 // Schéma pour la mise à jour (tous les champs optionnels)
-export const userUpdateSchema = userSchema.partial();
+export const userUpdateSchema = userSchema
+  .partial()
+  .openapi("UserUpdateInput");
 
-// Types générés automatiquement
 export type UserInput = z.infer<typeof userSchema>;
 export type UserUpdateInput = z.infer<typeof userUpdateSchema>;

--- a/src/swagger/config.ts
+++ b/src/swagger/config.ts
@@ -1,0 +1,40 @@
+import { OpenAPIRegistry, OpenApiGeneratorV3 } from '@asteasolutions/zod-to-openapi';
+import { userSchema, userUpdateSchema } from '../schemas/userSchema';
+import { SERVER } from '../config/server';
+import { z } from 'zod';
+import { Router } from 'express';
+import swaggerUi from 'swagger-ui-express';
+import { registerRoutes } from './routes/routes';
+
+// 1. Créer le registre OpenAPI
+export const registry = new OpenAPIRegistry();
+
+// 2. Enregistrer les routes
+
+
+// 3. Générer le document OpenAPI
+// Remplacer la fonction generateOpenApiDocument avec cette version corrigée
+function generateOpenApiDocument() {
+  // Initialiser avec la configuration de base
+const generator = new OpenApiGeneratorV3(registry.definitions);
+return generator.generateDocument({
+  openapi: '3.0.0',
+  info: {
+    version: '1.0.0',
+    title: 'API Médiathèque - Documentation',
+    description: 'API pour la gestion des utilisateurs de la médiathèque',
+  },
+    servers: [{ url: `http://${SERVER.hostname}:${SERVER.port}` }],
+});
+}
+
+// 4. Initialiser Swagger
+export function setupSwagger() {
+  registerRoutes();
+  const router = Router();
+  router.use('/', swaggerUi.serve);
+  router.get('/', swaggerUi.setup(generateOpenApiDocument(), {
+    customSiteTitle: 'API Médiathèque - Documentation'
+  }));
+  return router;
+}

--- a/src/swagger/routes/routes.ts
+++ b/src/swagger/routes/routes.ts
@@ -1,0 +1,7 @@
+import {registerUserRoutes} from './userRoutes';
+
+export const registerRoutes = () => {
+
+  registerUserRoutes();
+
+}

--- a/src/swagger/routes/userRoutes.ts
+++ b/src/swagger/routes/userRoutes.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+import { registry } from '../config';
+import { userSchema, userUpdateSchema } from '../../schemas/userSchema';
+
+export function registerUserRoutes() {
+  // POST /users - Créer un utilisateur
+  registry.registerPath({
+    method: 'post',
+    path: '/api/users',
+    tags: ['Users'],
+    summary: 'Créer un nouvel utilisateur',
+    request: { 
+      body: { 
+        content: { 
+          'application/json': { 
+            schema: userSchema
+          } 
+        } 
+      } 
+    },
+    responses: {
+      201: { 
+        description: 'Utilisateur créé avec succès',
+        content: {
+          'application/json': {
+            schema: userSchema
+          }
+        }
+      },
+      400: { description: 'Données invalides' }
+    }
+  });
+
+  // GET /users - Liste des utilisateurs
+  registry.registerPath({
+    method: 'get',
+    path: '/api/users',
+    tags: ['Users'],
+    summary: 'Récupérer tous les utilisateurs',
+    responses: {
+      200: { 
+        description: 'Liste des utilisateurs',
+        content: {
+          'application/json': {
+            schema: z.array(userSchema)
+          }
+        }
+      }
+    }
+  });
+
+  // GET /users/{id} - Récupérer un utilisateur
+  registry.registerPath({
+    method: 'get',
+    path: '/api/users/{id}',
+    tags: ['Users'],
+    summary: 'Récupérer un utilisateur par ID',
+    request: {
+      params: z.object({
+        id: z.string().openapi({ 
+          description: 'ID de l\'utilisateur',
+          example: '507f1f77bcf86cd799439011' 
+        })
+      })
+    },
+    responses: {
+      200: { 
+        description: 'Utilisateur trouvé',
+        content: {
+          'application/json': {
+            schema: userSchema
+          }
+        }
+      },
+      404: { description: 'Utilisateur non trouvé' }
+    }
+  });
+
+  // PUT /users/{id} - Mettre à jour un utilisateur
+  registry.registerPath({
+    method: 'put',
+    path: '/api/users/{id}',
+    tags: ['Users'],
+    summary: 'Mettre à jour un utilisateur',
+    request: {
+      params: z.object({
+        id: z.string().openapi({ description: 'ID de l\'utilisateur' })
+      }),
+      body: { 
+        content: { 
+          'application/json': { 
+            schema: userUpdateSchema
+          } 
+        } 
+      }
+    },
+    responses: {
+      200: { 
+        description: 'Utilisateur mis à jour',
+        content: {
+          'application/json': {
+            schema: userSchema
+          }
+        }
+      },
+      404: { description: 'Utilisateur non trouvé' }
+    }
+  });
+
+  // DELETE /users/{id} - Supprimer un utilisateur
+  registry.registerPath({
+    method: 'delete',
+    path: '/api/users/{id}',
+    tags: ['Users'],
+    summary: 'Supprimer un utilisateur',
+    request: {
+      params: z.object({
+        id: z.string().openapi({ description: 'ID de l\'utilisateur' })
+      })
+    },
+    responses: {
+      200: { description: 'Utilisateur supprimé' },
+      404: { description: 'Utilisateur non trouvé' }
+    }
+  });
+}


### PR DESCRIPTION

# 📚 Intégration de la documentation API Swagger

## 📝 Description
Cette PR ajoute une documentation API interactive à notre projet en utilisant **Swagger UI** et **zod-to-openapi**.  
La documentation est générée automatiquement à partir de nos schémas **Zod** existants, garantissant ainsi une synchronisation parfaite entre la validation de données et la documentation.

---

## ✅ Fonctionnalités ajoutées

- ✅ Interface Swagger UI accessible à `/api-docs`
- ✅ Documentation complète des endpoints utilisateurs (`GET`, `POST`, `PUT`, `DELETE`)
- ✅ Schémas de requêtes et réponses avec exemples
- ✅ Description détaillée des paramètres et des codes de statut
- ✅ Structure modulaire facilitant l’ajout de nouvelles routes

---

## 🥪 Comment tester

1. Installer les dépendances :
   ```bash
   npm install
   ```

2. Démarrer le serveur :
   ```bash
   npm run dev
   ```

3. Accéder à la documentation :
   [http://localhost:1337/api-docs](http://localhost:1337/api-docs)

4. Essayer les différents endpoints directement depuis l’interface Swagger

---

## 🚀 Avantages

- 📝 Facilite l’onboarding des nouveaux développeurs
- 🥪 Permet de tester rapidement les API sans outil externe (ex: Postman)
- 🔄 Reste **synchronisée** avec le code grâce à l’utilisation des schémas Zod
- 🚰 Améliore la **maintenabilité** via une architecture modulaire

---

## 📦 Dépendances ajoutées

| Package                                 | Rôle                                                       |
|-----------------------------------------|-------------------------------------------------------------|
| `swagger-ui-express`                    | Interface utilisateur Swagger                              |
| `@asteasolutions/zod-to-openapi`        | Conversion des schémas Zod en OpenAPI                      |
| `@types/swagger-ui-express`             | Typage TypeScript pour Swagger UI Express                  |
