### PR TITLE
Mediatheque: Closes #11 - Adapt user service and model to use UUID

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "express": "^4.21.2",
     "mongoose": "^8.15.1",
     "swagger-ui-express": "^5.0.1",
+    "uuid": "^11.1.0",
     "zod": "^3.25.51"
   },
   "devDependencies": {
@@ -25,6 +26,7 @@
     "@types/dotenv": "^8.2.0",
     "@types/express": "^4.17.21",
     "@types/swagger-ui-express": "^4.1.8",
+    "@types/uuid": "^10.0.0",
     "nodemon": "^3.1.0",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.5"

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,17 +1,24 @@
 import mongoose, { Schema, Document } from 'mongoose';
 import { UserInput } from '../schemas/userSchema';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface IUser extends Document, UserInput {}
 
 // Mongoose schema for User from zod schema and additional properties
-const UserSchema: Schema = new Schema({
-  nom: { type: String, required: true },
-  prenom: { type: String, required: true },
-  mail: { type: String, required: true, unique: true },
-  telephone: { type: String, required: true },
-  nationalite: { type: String, required: true }
+const UserSchema: Schema = new Schema({                 
+    userId: {
+        type: String,
+        unique: true,
+        default: () => uuidv4(), 
+        immutable: true
+    },
+    nom: { type: String, required: true },
+    prenom: { type: String, required: true },
+    mail: { type: String, required: true, unique: true },
+    telephone: { type: String, required: true },
+    nationalite: { type: String, required: true }
 }, {
-  timestamps: true
+    timestamps: true
 });
 
 export default mongoose.model<IUser>('User', UserSchema);

--- a/src/services/userService.ts
+++ b/src/services/userService.ts
@@ -17,16 +17,16 @@ export class UserService implements IUserService {
     return await User.find();
   }
 
-  async getUserById(id: string): Promise<IUser | null> {
-    return await User.findById(id);
+  async getUserById(userId: string): Promise<IUser | null> {
+    return await User.findOne({ userId });
   }
 
-  async updateUser(id: string, userData: UserUpdateInput): Promise<IUser | null> {
-    return await User.findByIdAndUpdate(id, userData, { new: true, runValidators: true });
+  async updateUser(userId: string, userData: UserUpdateInput): Promise<IUser | null> {
+    return await User.findOneAndUpdate({ userId }, userData, { new: true, runValidators: true });
   }
 
-  async deleteUser(id: string): Promise<boolean> {
-    const result = await User.findByIdAndDelete(id);
+  async deleteUser(userId: string): Promise<boolean> {
+    const result = await User.findOneAndDelete({ userId });
     return result !== null;
   }
 }


### PR DESCRIPTION
# 🚀 Amélioration : Passage à un identifiant utilisateur UUID public (`userId`)

## Résumé

Cette PR remplace l’utilisation de l’identifiant MongoDB natif (`_id`) par un identifiant public unique, sécurisé et immuable basé sur UUID v4, nommé `userId`. Cela améliore la sécurité et la clarté des interactions avec l’API.

---

## Changements principaux

- ✨ Ajout du champ `userId` dans le schéma Mongoose, généré automatiquement via `uuidv4()`, avec unicité et immutabilité garanties.
- 🔄 Mise à jour des méthodes du service utilisateur pour effectuer les recherches, mises à jour et suppressions via `userId` au lieu de `_id`.

---

## Pourquoi ?

- **Sécurité :** Le `userId` UUID est non prédictible, évitant d’exposer l’identifiant MongoDB interne.
- **Clarté :** `userId` est plus intuitif pour les consommateurs de l’API que `_id`.
- **Fiabilité** : Le risque de collision avec UUID v4 est extrêmement faible, ce qui garantit l’unicité des identifiants publics sans nécessiter de gestion complexe.

---

## Impact

- Toutes les requêtes liées aux utilisateurs doivent désormais utiliser `userId` en lieu et place de `_id`.
- Migration transparente pour les données existantes, sans impact sur le stockage MongoDB.

---