### PR TITLE
improvement: add fr date formatting to API responses #19

### DIFF
--- a/logs/combined.log
+++ b/logs/combined.log
@@ -159,3 +159,6 @@ Error: Phone number already in use
 [2025-06-19 02:12:41] error: [userController] Error creating user: AppError: Email already in use
 [2025-06-19 02:18:21] error: [empruntService] Emprunt with ID a289827a-3ce5-47c7-b953-c7c36d399e13 not found
 [2025-06-19 02:18:21] error: [empruntController] Error returning emprunt with ID a289827a-3ce5-47c7-b953-c7c36d399e13: AppError: Emprunt not found
+[2025-06-19 09:20:00] error: [userController] Error fetching users: TypeError: Cannot read properties of undefined (reading 'toLocaleDateString')
+[2025-06-19 09:20:03] error: [userController] Error fetching users: TypeError: Cannot read properties of undefined (reading 'toLocaleDateString')
+[2025-06-19 09:22:16] info: [userController] Fetched 7 users

--- a/logs/error.log
+++ b/logs/error.log
@@ -115,3 +115,5 @@ Error: Phone number already in use
 [2025-06-19 02:12:41] error: [userController] Error creating user: AppError: Email already in use
 [2025-06-19 02:18:21] error: [empruntService] Emprunt with ID a289827a-3ce5-47c7-b953-c7c36d399e13 not found
 [2025-06-19 02:18:21] error: [empruntController] Error returning emprunt with ID a289827a-3ce5-47c7-b953-c7c36d399e13: AppError: Emprunt not found
+[2025-06-19 09:20:00] error: [userController] Error fetching users: TypeError: Cannot read properties of undefined (reading 'toLocaleDateString')
+[2025-06-19 09:20:03] error: [userController] Error fetching users: TypeError: Cannot read properties of undefined (reading 'toLocaleDateString')

--- a/src/models/Emprunt.ts
+++ b/src/models/Emprunt.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Document, Types } from 'mongoose';
 import { v4 as uuidv4 } from 'uuid';
 import { EmpruntZodType } from '../schemas/empruntSchema';
+import { formatToFrDate } from '../utils/dateUtils';
 
 export interface IEmprunt extends Document, EmpruntZodType {}
 
@@ -22,6 +23,13 @@ const EmpruntSchema = new Schema(
     timestamps: true,
     toJSON: {
       transform(_, ret) {
+        // Date formatting
+        ret.dateEmprunt = formatToFrDate(ret.dateEmprunt);
+        ret.dateRetour = formatToFrDate(ret.dateRetour);
+        ret.createdAt = formatToFrDate(ret.createdAt);
+        ret.updatedAt = formatToFrDate(ret.updatedAt);
+
+        // Remove unnecessary fields for security purposes
         delete ret._id;
         delete ret.__v;
         return ret;

--- a/src/models/Ressource.ts
+++ b/src/models/Ressource.ts
@@ -1,7 +1,7 @@
 import mongoose, { Schema, Document } from 'mongoose';
 import { RessourceZodType } from '../schemas/ressourceSchema';
 import { v4 as uuidv4 } from 'uuid';
-
+import { formatToFrDate } from '../utils/dateUtils';
 
 export interface IRessources extends Document, RessourceZodType {}
 
@@ -26,6 +26,11 @@ const RessourceSchema: Schema = new Schema(
     timestamps: true,
     toJSON: {
       transform(_, ret) {
+        // Date formatting
+        ret.createdAt = formatToFrDate(ret.createdAt);
+        ret.updatedAt = formatToFrDate(ret.updatedAt);
+
+        // Remove unnecessary fields for security purposes
         delete ret._id;
         delete ret.__v;
         return ret;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -1,6 +1,7 @@
 import mongoose, { Schema, Document } from 'mongoose';
 import { UserZodType } from '../schemas/userSchema';
 import { v4 as uuidv4 } from 'uuid';
+import { formatToFrDate } from '../utils/dateUtils';
 
 export interface IUser extends Document, UserZodType {}
 
@@ -21,6 +22,11 @@ const UserSchema: Schema = new Schema({
     timestamps: true,
     toJSON: {
       transform(_, ret) {
+        // Date formatting
+        ret.createdAt = formatToFrDate(ret.createdAt);
+        ret.updatedAt = formatToFrDate(ret.updatedAt);
+
+        // Remove unnecessary fields for security purposes
         delete ret._id;
         delete ret.__v;
         return ret;

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -1,3 +1,5 @@
+
+
 export function formatToFrDate(date: Date): string {
   return date.toLocaleDateString('fr-FR').replace(/\//g, '-');
 }


### PR DESCRIPTION
# Pull Request Comments

## 🎯 Objectif

Cette Pull Request introduit le **formatage des dates en français** (`fr-FR`) dans les réponses envoyées côté client. L'objectif est de rendre les dates plus lisibles et adaptées à l'affichage dans une application francophone, sans impacter le stockage ou la logique interne de traitement des dates. Tout cela sachant que la gestion des dates dans mongo ne sont pas optimisé pour les dates (`fr-FR`)

---

## ✨ Changements apportés

- 🗓️ Ajout d’une méthode de transformation personnalisée dans les options `toJSON` des schémas Mongoose pour formater les champs de type `Date` (comme `dateEmprunt`, `dateRetour`, `createdAt`, `updatedAt`).
- 🔧 Création d’un utilitaire `formatToFrDate()` dans `utils/dateUtils.ts` pour unifier le formatage de toutes les dates.
- 🧹 Suppression des champs techniques `_id` et `__v` dans les réponses JSON envoyées au client.

---

## 📦 Exemple de transformation

Avant (format brut JSON) :
```json
{
  "dateEmprunt": "2025-06-19T10:45:00.000Z"
}
```
Après transformation (format brut JSON) :

```json
{
  "dateEmprunt": "19-06-2025"
}
```

